### PR TITLE
keras_flops 라이브러리를 활용한 flops 계산 

### DIFF
--- a/util/keras_flops.py
+++ b/util/keras_flops.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+from keras_flops import get_flops
+from tensorflow.keras.applications import (
+        mobilenet,
+        mobilenet_v2,
+        inception_v3
+        )
+
+mobilenet_v1 = mobilenet.MobileNet(weights='imagenet')
+mobilenet_v2 = mobilenet_v2.MobileNetV2(weights='imagenet')
+inception_v3 = inception_v3.InceptionV3(weights='imagenet')
+yolo_v5=tf.saved_model.load('yolov5s_saved_model')
+
+# Calculae FLOPS
+flops = get_flops(yolo_v5, batch_size=1)
+print(f"FLOPS: {flops / 10 ** 9:.03} G")

--- a/utils/flops/keras_flops.py
+++ b/utils/flops/keras_flops.py
@@ -9,7 +9,6 @@ from tensorflow.keras.applications import (
 mobilenet_v1 = mobilenet.MobileNet(weights='imagenet')
 mobilenet_v2 = mobilenet_v2.MobileNetV2(weights='imagenet')
 inception_v3 = inception_v3.InceptionV3(weights='imagenet')
-yolo_v5=tf.saved_model.load('yolov5s_saved_model')
 
 # Calculae FLOPS
 flops = get_flops(yolo_v5, batch_size=1)


### PR DESCRIPTION
keras_flops 라이브러리를 활용하여 keras api로 제공되는 모델(mobilenet v1, v2, inception v3 - TF/FP32)의 batch 단위별 flops 계산

https://github.com/ddps-lab/edge-management-module/issues/1 
이슈와 관련이 있습니다.